### PR TITLE
Fix duplicate CSS include

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,8 +3,6 @@
 
 <title>{% if post.title %}{{ post.title }} | {{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
 
-<link rel="stylesheet" href="{{ site.baseurl }}/node_modules/reveal.js/css/reveal.css">
-
 <link rel="stylesheet" href="{{site.baseurl}}/node_modules/reveal.js/css/reset.css">
 <link rel="stylesheet" href="{{site.baseurl}}/node_modules/reveal.js/css/reveal.css">
 <link rel="stylesheet" href="{{site.baseurl}}/node_modules/reveal.js/css/theme/moon.css">


### PR DESCRIPTION
## Summary
- dedupe reveal.js CSS link in head.html

## Testing
- `./script/cibuild` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684050adefe4832697008ca56e78a799